### PR TITLE
HOME-160 - Separate CMD API package from smarthome and smarthome-cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,18 @@
+package agentscmdapi
+
+var (
+	ApiMap = map[string]string{
+		"jeep-v0.2.2": "jeep-api-v0.1.0",
+	}
+	Comms = map[string]map[string][]string{
+		"jeep-api-v0.1.0": map[string][]string{
+			"s":          []string{"CMD010", "CMD020"},
+			"w":          []string{"CMD010", "CMD020", "CMD012", "CMD022"},
+			"a":          []string{"CMD010", "CMD020", "CMD012", "CMD122"},
+			"d":          []string{"CMD010", "CMD020", "CMD112", "CMD022"},
+			"x":          []string{"CMD010", "CMD020", "CMD112", "CMD122"},
+			"l":          []string{"CMDLOK"},
+			"disconnect": []string{"CMDDIS"},
+		},
+	}
+)


### PR DESCRIPTION
**Business requirement:** https://trello.com/c/P2hcrm2n/160-home-160-separate-cmd-api-package-from-smarthome-and-smarthome-cli

**Description:** CMD API needs to be separated into a dedicated repository as a lot of other repositories use it.