### PR TITLE
HOME-175 - Use Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/smart-evolution/agents-cmd-api
+
+go 1.12

--- a/main.go
+++ b/main.go
@@ -1,0 +1,18 @@
+package agentscmdapi
+
+var (
+	ApiMap = map[string]string{
+		"jeep-v0.2.2": "jeep-api-v0.1.0",
+	}
+	Comms = map[string]map[string][]string{
+		"jeep-api-v0.1.0": map[string][]string{
+			"s":          []string{"CMD010", "CMD020"},
+			"w":          []string{"CMD010", "CMD020", "CMD012", "CMD022"},
+			"a":          []string{"CMD010", "CMD020", "CMD012", "CMD122"},
+			"d":          []string{"CMD010", "CMD020", "CMD112", "CMD022"},
+			"x":          []string{"CMD010", "CMD020", "CMD112", "CMD122"},
+			"l":          []string{"CMDLOK"},
+			"disconnect": []string{"CMDDIS"},
+		},
+	}
+)


### PR DESCRIPTION
**Business justification:** https://trello.com/c/TRjWNUPf/174-home-175-use-go-modules

**Description:** Go is evolving and since 1.11 modules are present and `$GOPATH` will be deprecated. As new version of go will be involved we need to adjust modules support.